### PR TITLE
Add ContainsLowercase case to ValidationPattern enum

### DIFF
--- a/Validator/Validator/Rules/ValidationRulePattern.swift
+++ b/Validator/Validator/Rules/ValidationRulePattern.swift
@@ -33,6 +33,7 @@ public enum ValidationPattern: String {
     case EmailAddress = "^[_A-Za-z0-9-+]+(\\.[_A-Za-z0-9-+]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9-]+)*(\\.[A-Za-z‌​]{2,})$"
     case ContainsNumber = ".*\\d.*"
     case ContainsCapital = "^.*?[A-Z].*?$"
+    case ContainsLowercase = "^.*?[a-z].*?$"
 }
 
 public struct ValidationRulePattern: ValidationRule {


### PR DESCRIPTION
Just a simple `.ContainsLowercase` validation pattern to compliment the existing `.ContainsCapital` when validating passwords etc. I think the `.ContainsCapital` case should then be renamed to `.ContainsUppercase`, however, I didn't wish to make breaking changes to the project.

Thanks