### PR TITLE
fix to selector and associatedtype

### DIFF
--- a/Validator/Validator/UIKit+Validator/UISlider+Validator.swift
+++ b/Validator/Validator/UIKit+Validator/UISlider+Validator.swift
@@ -37,8 +37,8 @@ extension UISlider: ValidatableInterfaceElement {
     
     public func validateOnInputChange(validationEnabled: Bool) {
         switch validationEnabled {
-        case true: addTarget(self, action: "validateInput:", forControlEvents: .ValueChanged)
-        case false: removeTarget(self, action: "validateInput:", forControlEvents: .ValueChanged)
+        case true: addTarget(self, action: #selector(UISlider.validateInput(_:)), forControlEvents: .ValueChanged)
+        case false: removeTarget(self, action: #selector(UISlider.validateInput(_:)), forControlEvents: .ValueChanged)
         }
     }
     

--- a/Validator/Validator/UIKit+Validator/UITextField+Validator.swift
+++ b/Validator/Validator/UIKit+Validator/UITextField+Validator.swift
@@ -37,15 +37,15 @@ extension UITextField: ValidatableInterfaceElement {
     
     public func validateOnInputChange(validationEnabled: Bool) {
         switch validationEnabled {
-        case true: addTarget(self, action: "validateInput:", forControlEvents: .EditingChanged)
-        case false: removeTarget(self, action: "validateInput:", forControlEvents: .EditingChanged)
+        case true: addTarget(self, action: #selector(UITextField.validateInput(_:)), forControlEvents: .EditingChanged)
+        case false: removeTarget(self, action: #selector(UITextField.validateInput(_:)), forControlEvents: .EditingChanged)
         }
     }
     
     public func validateOnEditingEnd(validationEnabled: Bool) {
         switch validationEnabled {
-        case true: addTarget(self, action: "validateInput:", forControlEvents: .EditingDidEnd)
-        case false: removeTarget(self, action: "validateInput:", forControlEvents: .EditingDidEnd)
+        case true: addTarget(self, action: #selector(UITextField.validateInput(_:)), forControlEvents: .EditingDidEnd)
+        case false: removeTarget(self, action: #selector(UITextField.validateInput(_:)), forControlEvents: .EditingDidEnd)
         }
     }
     

--- a/Validator/Validator/UIKit+Validator/ValidatableInterfaceElement.swift
+++ b/Validator/Validator/UIKit+Validator/ValidatableInterfaceElement.swift
@@ -32,7 +32,7 @@ import ObjectiveC
 
 public protocol ValidatableInterfaceElement: AnyObject {
     
-    typealias InputType: Validatable
+    associatedtype InputType: Validatable
     
     var inputValue: InputType? { get }
     

--- a/Validator/Validator/ValidationRule.swift
+++ b/Validator/Validator/ValidationRule.swift
@@ -31,7 +31,7 @@ import Foundation
 
 public protocol ValidationRule {
     
-    typealias InputType
+    associatedtype InputType
     
     func validateInput(input: InputType?) -> Bool
     


### PR DESCRIPTION
Swift 2.2 syntax
warning: use of 'typealias' to declare associated types is deprecated; use 'associatedtype' instead.
and
warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead