### PR TITLE
added an init(rules:) method to the ValidationRuleSet

### DIFF
--- a/Validator/Validator/ValidationRuleSet.swift
+++ b/Validator/Validator/ValidationRuleSet.swift
@@ -34,6 +34,10 @@ public struct ValidationRuleSet<InputType> {
     
     }
     
+    public init<R: ValidationRule where R.InputType == InputType>(rules: [R]) {
+        self.rules = rules.map(AnyValidationRule.init)
+    }
+    
     internal var rules = [AnyValidationRule<InputType>]()
     
     public mutating func addRule<R: ValidationRule where R.InputType == InputType>(rule: R) {


### PR DESCRIPTION
This should help reduce the amount of lines it takes to create a ruleset. It would be even better if we could make the `ValidationRuleSet` `ArrayLiteralConvertible` but that isn't straightforward it seems.