### PR TITLE
Add CocoaPods Badge with current released version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Validator [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+# Validator
+
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) [![CocoaPods Compatible](https://img.shields.io/badge/pod-2.1.0-blue.svg)](https://github.com/CocoaPods/CocoaPods)
 
 Validator is a user input validation library written in Swift. It's comprehensive, designed for extension, and leaves error handling and the UI up to you (as it should be).
 


### PR DESCRIPTION
Badge Version should be changed while tagging a new version.
If too much work, this badge could be changed to just say

CocoaPods: Compatible