### PR TITLE
Now valid if no rules attached to ValidatableInterfaceElement + tests

### DIFF
--- a/Validator/Validator/UIKit+Validator/ValidatableInterfaceElement.swift
+++ b/Validator/Validator/UIKit+Validator/ValidatableInterfaceElement.swift
@@ -153,7 +153,12 @@ extension ValidatableInterfaceElement {
     }
     
     @discardableResult public func validate() -> ValidationResult {
-        guard let attachedRules = validationRules else { fatalError("Validator Error: attempted to validate without attaching rules") }
+        guard let attachedRules = validationRules else {
+            #if DEBUG
+                print("Validator Error: attempted to validate without attaching rules")
+            #endif
+            return .valid
+        }
         return validate(rules: attachedRules)
     }
     

--- a/Validator/ValidatorTests/UIKit+Validator/UITextField+ValidatorTests.swift
+++ b/Validator/ValidatorTests/UIKit+Validator/UITextField+ValidatorTests.swift
@@ -45,6 +45,8 @@ class UITextFieldValidatorTests: XCTestCase {
     func testThatItCanValidateInputText() {
         let textField = UITextField()
         textField.text = "Hello"
+        let noRulesValidation = textField.validate()
+        XCTAssertTrue(noRulesValidation.isValid)
         let rule = ValidationRuleCondition<String>(error: testError) { ($0?.characters.contains("A"))! }
         let invalid = textField.validate(rule: rule)
         XCTAssertFalse(invalid.isValid)


### PR DESCRIPTION
resolves #68

No more fatal error for `ValidatableInterfaceElement` if no rules attached to it. Still printing warning to the console in Debug environment, thus it could be unwanted behavior.