### PR TITLE
Support character code type in `ValidationRuleLength`

### DIFF
--- a/Validator/Validator/Rules/ValidationRuleLength.swift
+++ b/Validator/Validator/Rules/ValidationRuleLength.swift
@@ -37,6 +37,18 @@ import Foundation
  
  */
 public struct ValidationRuleLength: ValidationRule {
+
+    /**
+     
+     `String` text count type.
+
+     */
+    public enum LengthType {
+        case characters
+        case utf8
+        case utf16
+        case unicodeScalars
+    }
     
     public typealias InputType = String
 
@@ -55,7 +67,14 @@ public struct ValidationRuleLength: ValidationRule {
      
      */
     public let max: Int
-    
+
+    /**
+
+     The `String` text count type an input most have (default .characters).
+
+     */
+    public let lengthType: LengthType
+
     /**
      
      Initializes a `ValidationRuleLength` with an optionally supplied minimum 
@@ -65,12 +84,14 @@ public struct ValidationRuleLength: ValidationRule {
      - Parameters:
         - min: A minimum character count an input must have (default 0).
         - max: A maximum character count an input must have (default Int.max).
+        - lengthType: A `String` text count type an input most have (default .characters).
         - error: An error describing a failed validation.
      
      */
-    public init(min: Int = 0, max: Int = Int.max, error: Error) {
+    public init(min: Int = 0, max: Int = Int.max, lengthType: LengthType = .characters, error: Error) {
         self.min = min
         self.max = max
+        self.lengthType = lengthType
         self.error = error
     }
     
@@ -80,14 +101,23 @@ public struct ValidationRuleLength: ValidationRule {
      
      - Parameters:
         - input: Input to validate.
-     
+
      - Returns:
      true if the input character count is between the minimum and maximum.
      
      */
     public func validate(input: String?) -> Bool {
         guard let input = input else { return false }
-        return input.characters.count >= min && input.characters.count <= max
+
+        let length: Int
+        switch lengthType {
+        case .characters: length = input.characters.count
+        case .utf8: length = input.utf8.count
+        case .utf16: length = input.utf16.count
+        case .unicodeScalars: length = input.unicodeScalars.count
+        }
+
+        return length >= min && length <= max
     }
 
 }

--- a/Validator/ValidatorTests/Rules/ValidationRuleLengthTests.swift
+++ b/Validator/ValidatorTests/Rules/ValidationRuleLengthTests.swift
@@ -72,5 +72,100 @@ class ValidationRuleLengthTests: XCTestCase {
         }
         
     }
-    
+
+    func testThatItCanValidateEmojiCharacthersMinLength() {
+        // NOTE: "🇯🇵".characters.count = 1
+
+        let rule = ValidationRuleLength(min: 2, error: testError)
+
+        let tooShort = Validator.validate(input: "🇯🇵", rule: rule)
+        XCTAssertFalse(tooShort.isValid)
+
+        let valid = Validator.validate(input: "🇯🇵🇯🇵", rule: rule)
+        XCTAssertFalse(valid.isValid)
+    }
+
+    func testThatItCanValidateEmojiCharacthersMaxLength() {
+        // NOTE: "🇯🇵".characters.count = 1
+
+        let rule = ValidationRuleLength(max: 2, error: testError)
+
+        let tooLong = Validator.validate(input: "🇯🇵🇯🇵🇯🇵", rule: rule)
+        XCTAssertTrue(tooLong.isValid)
+
+        let valid = Validator.validate(input: "🇯🇵🇯🇵", rule: rule)
+        XCTAssertTrue(valid.isValid)
+    }
+
+    func testThatItCanValidateEmojiUTF8MinLength() {
+        // NOTE: "🇯🇵".utf8.count = 8
+
+        let rule = ValidationRuleLength(min: 16, lengthType: .utf8, error: testError)
+
+        let tooShort = Validator.validate(input: "🇯🇵", rule: rule)
+        XCTAssertFalse(tooShort.isValid)
+
+        let valid = Validator.validate(input: "🇯🇵🇯🇵", rule: rule)
+        XCTAssertTrue(valid.isValid)
+    }
+
+    func testThatItCanValidateEmojiUTF8MaxLength() {
+        // NOTE: "🇯🇵".utf8.count = 8
+
+        let rule = ValidationRuleLength(max: 16, lengthType: .utf8, error: testError)
+
+        let tooLong = Validator.validate(input: "🇯🇵🇯🇵🇯🇵", rule: rule)
+        XCTAssertFalse(tooLong.isValid)
+
+        let valid = Validator.validate(input: "🇯🇵🇯🇵", rule: rule)
+        XCTAssertTrue(valid.isValid)
+    }
+
+    func testThatItCanValidateEmojiUTF16MinLength() {
+        // NOTE: "🇯🇵".utf16.count = 4
+
+        let rule = ValidationRuleLength(min: 8, lengthType: .utf16, error: testError)
+
+        let tooShort = Validator.validate(input: "🇯🇵", rule: rule)
+        XCTAssertFalse(tooShort.isValid)
+
+        let valid = Validator.validate(input: "🇯🇵🇯🇵", rule: rule)
+        XCTAssertTrue(valid.isValid)
+    }
+
+    func testThatItCanValidateEmojiUTF16MaxLength() {
+        // NOTE: "🇯🇵".utf16.count = 4
+
+        let rule = ValidationRuleLength(max: 8, lengthType: .utf16, error: testError)
+
+        let tooLong = Validator.validate(input: "🇯🇵🇯🇵🇯🇵", rule: rule)
+        XCTAssertFalse(tooLong.isValid)
+
+        let valid = Validator.validate(input: "🇯🇵🇯🇵", rule: rule)
+        XCTAssertTrue(valid.isValid)
+    }
+
+    func testThatItCanValidateEmojiUnicodeScalarsMinLength() {
+        // NOTE: "🇯🇵".unicodeScalars.count = 2
+
+        let rule = ValidationRuleLength(min: 4, lengthType: .unicodeScalars, error: testError)
+
+        let tooShort = Validator.validate(input: "🇯🇵", rule: rule)
+        XCTAssertFalse(tooShort.isValid)
+
+        let valid = Validator.validate(input: "🇯🇵🇯🇵", rule: rule)
+        XCTAssertTrue(valid.isValid)
+    }
+
+    func testThatItCanValidateEmojiUnicodeScalarsMaxLength() {
+        // NOTE: "🇯🇵".unicodeScalars.count = 2
+
+        let rule = ValidationRuleLength(max: 4, lengthType: .unicodeScalars, error: testError)
+
+        let tooLong = Validator.validate(input: "🇯🇵🇯🇵🇯🇵", rule: rule)
+        XCTAssertFalse(tooLong.isValid)
+
+        let valid = Validator.validate(input: "🇯🇵🇯🇵", rule: rule)
+        XCTAssertTrue(valid.isValid)
+    }
 }


### PR DESCRIPTION
Support `String.length` by specifing an character code of `ValidationRuleLength`.