### PR TITLE
Updated string length count for Swift 4

### DIFF
--- a/Validator/Sources/Rules/ValidationRuleLength.swift
+++ b/Validator/Sources/Rules/ValidationRuleLength.swift
@@ -111,7 +111,7 @@ public struct ValidationRuleLength: ValidationRule {
 
         let length: Int
         switch lengthType {
-        case .characters: length = input.characters.count
+        case .characters: length = input.count
         case .utf8: length = input.utf8.count
         case .utf16: length = input.utf16.count
         case .unicodeScalars: length = input.unicodeScalars.count

--- a/Validator/Sources/Rules/ValidationRulePaymentCard.swift
+++ b/Validator/Sources/Rules/ValidationRulePaymentCard.swift
@@ -247,7 +247,7 @@ public struct ValidationRulePaymentCard: ValidationRule {
     
     private static func luhnCheck(cardNumber: String) -> Bool {
         var sum = 0
-        let reversedCharacters = cardNumber.characters.reversed().map { String($0) }
+        let reversedCharacters = cardNumber.reversed().map { String($0) }
         for (idx, element) in reversedCharacters.enumerated() {
             guard let digit = Int(element) else { return false }
             switch ((idx % 2 == 1), digit) {

--- a/Validator/ValidatorTests/UIKit+Validator/UITextField+ValidatorTests.swift
+++ b/Validator/ValidatorTests/UIKit+Validator/UITextField+ValidatorTests.swift
@@ -47,7 +47,7 @@ class UITextFieldValidatorTests: XCTestCase {
         textField.text = "Hello"
         let noRulesValidation = textField.validate()
         XCTAssertTrue(noRulesValidation.isValid)
-        let rule = ValidationRuleCondition<String>(error: testError) { ($0?.characters.contains("A"))! }
+        let rule = ValidationRuleCondition<String>(error: testError) { ($0?.contains("A"))! }
         let invalid = textField.validate(rule: rule)
         XCTAssertFalse(invalid.isValid)
         textField.text = "Hello Adam"
@@ -59,7 +59,7 @@ class UITextFieldValidatorTests: XCTestCase {
         let textField = UITextField()
         
         var rules = ValidationRuleSet<String>()
-        let rule = ValidationRuleCondition<String>(error: testError) { ($0?.characters.contains("A"))! }
+        let rule = ValidationRuleCondition<String>(error: testError) { ($0?.contains("A"))! }
         rules.add(rule: rule)
         
         var didRegisterInvalid = false

--- a/Validator/ValidatorTests/Validatable/ValidatableTests.swift
+++ b/Validator/ValidatorTests/Validatable/ValidatableTests.swift
@@ -34,7 +34,7 @@ class ValidatableTests: XCTestCase {
     
     func testThatItCanValidate() {
         
-        let rule = ValidationRuleCondition<String>(error: testError) { ($0?.characters.count)! > 0 }
+        let rule = ValidationRuleCondition<String>(error: testError) { ($0?.count)! > 0 }
         
         let invalid = "".validate(rule: rule)
         XCTAssertFalse(invalid.isValid)

--- a/Validator/ValidatorTests/Validator/ValidatorTests.swift
+++ b/Validator/ValidatorTests/Validator/ValidatorTests.swift
@@ -36,7 +36,7 @@ class ValidatorTests: XCTestCase {
         
         let err = testError
         
-        let rule = ValidationRuleCondition<String>(error: err) { ($0?.characters.count)! > 0 }
+        let rule = ValidationRuleCondition<String>(error: err) { ($0?.count)! > 0 }
         
         let invalid = Validator.validate(input: "", rule: rule)
         XCTAssertEqual(invalid, ValidationResult.invalid([err]))


### PR DESCRIPTION
Used `count` property directly on strings when counting string length. Strings are collections again in Swift 4 and `characters` property is deprecated (but still working for now).