### PR TITLE
Support Xcode9.1 - Swift 4

### DIFF
--- a/Validator/Sources/Rules/ValidationRuleLength.swift
+++ b/Validator/Sources/Rules/ValidationRuleLength.swift
@@ -111,7 +111,7 @@ public struct ValidationRuleLength: ValidationRule {
 
         let length: Int
         switch lengthType {
-        case .characters: length = input.characters.count
+        case .characters: length = input.count
         case .utf8: length = input.utf8.count
         case .utf16: length = input.utf16.count
         case .unicodeScalars: length = input.unicodeScalars.count

--- a/Validator/Sources/Rules/ValidationRulePaymentCard.swift
+++ b/Validator/Sources/Rules/ValidationRulePaymentCard.swift
@@ -247,7 +247,7 @@ public struct ValidationRulePaymentCard: ValidationRule {
     
     private static func luhnCheck(cardNumber: String) -> Bool {
         var sum = 0
-        let reversedCharacters = cardNumber.characters.reversed().map { String($0) }
+        let reversedCharacters = cardNumber.reversed().map { String($0) }
         for (idx, element) in reversedCharacters.enumerated() {
             guard let digit = Int(element) else { return false }
             switch ((idx % 2 == 1), digit) {


### PR DESCRIPTION
Fix 'characters' deprecated warning