### PR TITLE
Reduce iOS deployment target to iOS 9

### DIFF
--- a/Validator.podspec
+++ b/Validator.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
   s.name = 'Validator'
   s.platform = :ios
-  s.ios.deployment_target = '10.0'
+  s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '10.0'
   s.version = '3.1.0'
   s.summary = 'Validator is a user input validation library written in Swift.'

--- a/Validator.podspec
+++ b/Validator.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.platform = :ios
   s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '10.0'
-  s.version = '3.1.0'
+  s.version = '3.1.1'
   s.summary = 'Validator is a user input validation library written in Swift.'
   s.description  = <<-DESC
   Validator is a user input validation library written in Swift.


### PR DESCRIPTION
As per #106, iOS 9 is still supported by this library. This PR adjusts the podspec to reflect that.

(for interest: iOS 9.x is the latest version that can be run by the iPad 2 and iPhone 4S, among others)

tvOS has been left at a deployment target of 10.0 — it seems that all tvOS devices can run the newer versions of the OS.