### PR TITLE
Swift 5.1 compatibility: Rename validate to performValidation to prevent naming conflict

### DIFF
--- a/Example/Example/Views/LongStringExampleTableViewCell.swift
+++ b/Example/Example/Views/LongStringExampleTableViewCell.swift
@@ -23,7 +23,7 @@ final class LongStringExampleTableViewCell: ExampleTableViewCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        textView.validateOnInputChange(enabled: true)
+        textView.performValidationOnInputChange(enabled: true)
         textView.validationHandler = { result in self.updateValidationState(result: result) }
     }
     

--- a/Example/Example/Views/NumericExampleTableViewCell.swift
+++ b/Example/Example/Views/NumericExampleTableViewCell.swift
@@ -41,7 +41,7 @@ final class NumericExampleTableViewCell: ExampleTableViewCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        slider.validateOnInputChange(enabled: true)
+        slider.performValidationOnInputChange(enabled: true)
         slider.validationHandler = { result in self.updateValidationState(result: result) }
     }
     

--- a/Example/Example/Views/StringExampleTableViewCell.swift
+++ b/Example/Example/Views/StringExampleTableViewCell.swift
@@ -40,7 +40,7 @@ final class StringExampleTableViewCell: ExampleTableViewCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        textField.validateOnInputChange(enabled: true)
+        textField.performValdiationOnInputChange(enabled: true)
         textField.validationHandler = { result in self.updateValidationState(result: result) }
     }
     

--- a/Validator/Sources/Rules/ValidationRuleComparison.swift
+++ b/Validator/Sources/Rules/ValidationRuleComparison.swift
@@ -83,7 +83,7 @@ public struct ValidationRuleComparison<T: Comparable>: ValidationRule {
         true if the input is equal to or between the minimum and maximum.
      
      */
-    public func validate(input: T?) -> Bool {
+    public func performValidation(input: T?) -> Bool {
         guard let input = input else { return false }
         return input >= min && input <= max
     }

--- a/Validator/Sources/Rules/ValidationRuleCondition.swift
+++ b/Validator/Sources/Rules/ValidationRuleCondition.swift
@@ -38,7 +38,7 @@ import Foundation
     $0.contains("a") 
  }
  
- "Adam".validate(rule) // .valid
+ "Adam".performValidation(rule) // .valid
  ```
  
  */
@@ -81,7 +81,7 @@ public struct ValidationRuleCondition<T>: ValidationRule {
      true if the input satisifies the condition.
      
      */
-    public func validate(input: T?) -> Bool {
+    public func performValidation(input: T?) -> Bool {
         return condition(input)
     }
     

--- a/Validator/Sources/Rules/ValidationRuleContains.swift
+++ b/Validator/Sources/Rules/ValidationRuleContains.swift
@@ -76,7 +76,7 @@ public struct ValidationRuleContains<T: Equatable, S: Sequence>: ValidationRule 
      
      */
 
-    public func validate(input: T?) -> Bool {
+    public func performValidation(input: T?) -> Bool {
         guard let input = input else { return false }
         return sequence.contains(input)
     }

--- a/Validator/Sources/Rules/ValidationRuleEquality.swift
+++ b/Validator/Sources/Rules/ValidationRuleEquality.swift
@@ -109,7 +109,7 @@ public struct ValidationRuleEquality<T: Equatable>: ValidationRule {
      true if the input equals the target.
      
      */
-    public func validate(input: T?) -> Bool {
+    public func performValidation(input: T?) -> Bool {
         if let dynamicTarget = dynamicTarget {
             return input == dynamicTarget()
         }

--- a/Validator/Sources/Rules/ValidationRuleLength.swift
+++ b/Validator/Sources/Rules/ValidationRuleLength.swift
@@ -106,7 +106,7 @@ public struct ValidationRuleLength: ValidationRule {
      true if the input character count is between the minimum and maximum.
      
      */
-    public func validate(input: String?) -> Bool {
+    public func performValidation(input: String?) -> Bool {
         guard let input = input else { return false }
 
         let length: Int

--- a/Validator/Sources/Rules/ValidationRulePattern.swift
+++ b/Validator/Sources/Rules/ValidationRulePattern.swift
@@ -92,7 +92,7 @@ public struct ValidationRulePattern: ValidationRule {
      true if the input matched the regular expression.
      
      */
-    public func validate(input: String?) -> Bool {
+    public func performValidation(input: String?) -> Bool {
         return NSPredicate(format: "SELF MATCHES %@", pattern).evaluate(with: input)
     }
     

--- a/Validator/Sources/Rules/ValidationRulePaymentCard.swift
+++ b/Validator/Sources/Rules/ValidationRulePaymentCard.swift
@@ -238,7 +238,7 @@ public struct ValidationRulePaymentCard: ValidationRule {
      types.
      
      */
-    public func validate(input: String?) -> Bool {
+    public func performValidation(input: String?) -> Bool {
         guard let cardNum = input else { return false }
         guard ValidationRulePaymentCard.luhnCheck(cardNumber: cardNum) else { return false }
         guard let cardType = PaymentCardType(cardNumber: cardNum) else { return false }

--- a/Validator/Sources/Rules/ValidationRuleRequired.swift
+++ b/Validator/Sources/Rules/ValidationRuleRequired.swift
@@ -67,7 +67,7 @@ public struct ValidationRuleRequired<T>: ValidationRule {
      true if non-nil.
      
      */
-    public func validate(input: T?) -> Bool {        
+    public func performValidation(input: T?) -> Bool {        
         return input != nil
     }
     

--- a/Validator/Sources/Rules/ValidationRuleURL.swift
+++ b/Validator/Sources/Rules/ValidationRuleURL.swift
@@ -64,7 +64,7 @@ public struct ValidationRuleURL: ValidationRule {
      true if the input is a valid URL.
      
      */
-    public func validate(input: String?) -> Bool {
+    public func performValidation(input: String?) -> Bool {
         guard let input = input else { return false }
         return NSURL(string: input) != nil
     }

--- a/Validator/Sources/UIKit+Validator/UISlider+Validator.swift
+++ b/Validator/Sources/UIKit+Validator/UISlider+Validator.swift
@@ -36,15 +36,15 @@ extension UISlider: ValidatableInterfaceElement {
     
     open var inputValue: Float? { return value }
     
-    open func validateOnInputChange(enabled: Bool) {
+    open func performValidationOnInputChange(enabled: Bool) {
         switch enabled {
-        case true: addTarget(self, action: #selector(UISlider.validate), for: .valueChanged)
-        case false: removeTarget(self, action: #selector(UISlider.validate), for: .valueChanged)
+        case true: addTarget(self, action: #selector(UISlider.performValidation), for: .valueChanged)
+        case false: removeTarget(self, action: #selector(UISlider.performValidation), for: .valueChanged)
         }
     }
     
-    @objc private func validate(sender: UISlider) {
-        sender.validate()
+    @objc private func performValidation(sender: UISlider) {
+        sender.performValidation()
     }
     
 }

--- a/Validator/Sources/UIKit+Validator/UITextField+Validator.swift
+++ b/Validator/Sources/UIKit+Validator/UITextField+Validator.swift
@@ -35,22 +35,22 @@ extension UITextField: ValidatableInterfaceElement {
     
     open var inputValue: String? { return text }
     
-    open func validateOnInputChange(enabled: Bool) {
+    open func performValidationOnInputChange(enabled: Bool) {
         switch enabled {
-        case true: addTarget(self, action: #selector(validate), for: .editingChanged)
-        case false: removeTarget(self, action: #selector(validate), for: .editingChanged)
+        case true: addTarget(self, action: #selector(performValidation), for: .editingChanged)
+        case false: removeTarget(self, action: #selector(performValidation), for: .editingChanged)
         }
     }
     
     open func validateOnEditingEnd(enabled: Bool) {
         switch enabled {
-        case true: addTarget(self, action: #selector(validate), for: .editingDidEnd)
-        case false: removeTarget(self, action: #selector(validate), for: .editingDidEnd)
+        case true: addTarget(self, action: #selector(performValidation), for: .editingDidEnd)
+        case false: removeTarget(self, action: #selector(performValidation), for: .editingDidEnd)
         }
     }
     
-    @objc internal func validate(sender: UITextField) {
-        sender.validate()
+    @objc internal func performValidation(sender: UITextField) {
+        sender.performValidation()
     }
     
 }

--- a/Validator/Sources/UIKit+Validator/UITextView+Validator.swift
+++ b/Validator/Sources/UIKit+Validator/UITextView+Validator.swift
@@ -14,15 +14,15 @@ extension UITextView: ValidatableInterfaceElement {
     
     open var inputValue: String? { return text }
     
-    open func validateOnInputChange(enabled: Bool) {
+    open func performValidationOnInputChange(enabled: Bool) {
         switch enabled {
-        case true: NotificationCenter.default.addObserver(self, selector: #selector(validate), name: UITextView.textDidChangeNotification, object: self)
+        case true: NotificationCenter.default.addObserver(self, selector: #selector(performValidation), name: UITextView.textDidChangeNotification, object: self)
         case false: NotificationCenter.default.removeObserver(self, name: UITextView.textDidChangeNotification, object: self)
         }
     }
     
-    @objc internal func validate(_ sender: Notification) {
-        validate()
+    @objc internal func performValidation(_ sender: Notification) {
+        performValidation()
     }
     
 }

--- a/Validator/Sources/UIKit+Validator/ValidatableInterfaceElement.swift
+++ b/Validator/Sources/UIKit+Validator/ValidatableInterfaceElement.swift
@@ -84,7 +84,7 @@ public protocol ValidatableInterfaceElement: AnyObject {
      A validation result.
      
      */
-    func validate<R: ValidationRule>(rule r: R) -> ValidationResult
+    func performValidation<R: ValidationRule>(rule r: R) -> ValidationResult
     
     /**
      
@@ -97,7 +97,7 @@ public protocol ValidatableInterfaceElement: AnyObject {
      A validation result.
      
      */
-    func validate(rules: ValidationRuleSet<InputType>) -> ValidationResult
+    func performValidation(rules: ValidationRuleSet<InputType>) -> ValidationResult
     
     /**
      
@@ -107,7 +107,7 @@ public protocol ValidatableInterfaceElement: AnyObject {
         - enabled: `true` to start observation, `false` to end observation.
      
      */
-    func validateOnInputChange(enabled: Bool)
+    func performValidationOnInputChange(enabled: Bool)
     
 }
 
@@ -138,27 +138,27 @@ extension ValidatableInterfaceElement {
         }
     }
     
-    public func validate<R: ValidationRule>(rule r: R) -> ValidationResult {
+    public func performValidation<R: ValidationRule>(rule r: R) -> ValidationResult {
         guard let value = inputValue as? R.InputType else { return .invalid([r.error]) }
-        let result = Validator.validate(input: value, rule: r)
+        let result = Validator.performValidation(input: value, rule: r)
         validationHandler?(result)
         return result
     }
     
-    public func validate(rules rs: ValidationRuleSet<InputType>) -> ValidationResult {
-        let result = Validator.validate(input: inputValue, rules: rs)
+    public func performValidation(rules rs: ValidationRuleSet<InputType>) -> ValidationResult {
+        let result = Validator.performValidation(input: inputValue, rules: rs)
         validationHandler?(result)
         return result
     }
     
-    @discardableResult public func validate() -> ValidationResult {
+    @discardableResult public func performValidation() -> ValidationResult {
         guard let attachedRules = validationRules else {
             #if DEBUG
             print("Validator Error: attempted to validate without attaching rules")
             #endif
             return .valid
         }
-        return validate(rules: attachedRules)
+        return performValidation(rules: attachedRules)
     }
     
 }

--- a/Validator/Sources/Validatable.swift
+++ b/Validator/Sources/Validatable.swift
@@ -37,7 +37,7 @@ import Foundation
  ```
  extension String : Validatable {}
  
- "Hello world!".validate(rule: someRule)
+ "Hello world!".performValidation(rule: someRule)
  ```
  
  - Important:
@@ -58,7 +58,7 @@ public protocol Validatable {
      A validation result.
      
      */
-    func validate<R: ValidationRule>(rule: R) -> ValidationResult where R.InputType == Self
+    func performValidation<R: ValidationRule>(rule: R) -> ValidationResult where R.InputType == Self
     
     /**
      
@@ -71,18 +71,18 @@ public protocol Validatable {
      A validation result.
      
      */
-    func validate(rules: ValidationRuleSet<Self>) -> ValidationResult
+    func performValidation(rules: ValidationRuleSet<Self>) -> ValidationResult
     
 }
 
 extension Validatable {
     
-    public func validate<R: ValidationRule>(rule: R) -> ValidationResult where R.InputType == Self {
-        return Validator.validate(input: self, rule: rule)
+    public func performValidation<R: ValidationRule>(rule: R) -> ValidationResult where R.InputType == Self {
+        return Validator.performValidation(input: self, rule: rule)
     }
     
-    public func validate(rules: ValidationRuleSet<Self>) -> ValidationResult {
-        return Validator.validate(input: self, rules: rules)
+    public func performValidation(rules: ValidationRuleSet<Self>) -> ValidationResult {
+        return Validator.performValidation(input: self, rules: rules)
     }
     
 }

--- a/Validator/Sources/ValidationRule.swift
+++ b/Validator/Sources/ValidationRule.swift
@@ -56,13 +56,13 @@ public protocol ValidationRule {
      true if valid.
      
      */
-    func validate(input: InputType?) -> Bool
+    func performValidation(input: InputType?) -> Bool
     
     /**
      
      An error to be contained in an `.invalid` `ValidationResult` should an 
      input not satify the condition of the validation described by 
-     `validate(input:)`
+     `performValidation(input:)`
      
      */
     var error: Error { get }
@@ -76,11 +76,11 @@ internal struct AnyValidationRule<InputType>: ValidationRule {
     let error: Error
     
     init<R: ValidationRule>(base: R) where R.InputType == InputType {
-        baseValidateInput = base.validate
+        baseValidateInput = base.performValidation
         error = base.error
     }
     
-    func validate(input: InputType?) -> Bool {
+    func performValidation(input: InputType?) -> Bool {
         return baseValidateInput(input)
     }
 

--- a/Validator/Sources/Validator.swift
+++ b/Validator/Sources/Validator.swift
@@ -49,11 +49,11 @@ public struct Validator {
      A validation result.
      
      */
-    public static func validate<R: ValidationRule>(input: R.InputType?, rule: R) -> ValidationResult {
+    public static func performValidation<R: ValidationRule>(input: R.InputType?, rule: R) -> ValidationResult {
         
         var ruleSet = ValidationRuleSet<R.InputType>()
         ruleSet.add(rule: rule)
-        return Validator.validate(input: input, rules: ruleSet)
+        return Validator.performValidation(input: input, rules: ruleSet)
     }
     
     /**
@@ -68,8 +68,8 @@ public struct Validator {
      A validation result.
      
      */
-    public static func validate<T>(input: T?, rules: ValidationRuleSet<T>) -> ValidationResult {
-        let errors = rules.rules.filter { !$0.validate(input: input) }.map { $0.error }
+    public static func performValidation<T>(input: T?, rules: ValidationRuleSet<T>) -> ValidationResult {
+        let errors = rules.rules.filter { !$0.performValidation(input: input) }.map { $0.error }
         return errors.isEmpty ? .valid : .invalid(errors)
     }
     

--- a/Validator/ValidatorTests/Rules/ValidationRuleComparisonTests.swift
+++ b/Validator/ValidatorTests/Rules/ValidationRuleComparisonTests.swift
@@ -36,14 +36,14 @@ class ValidationRuleComparisonTests: XCTestCase {
 
         let rule = ValidationRuleComparison<Int>(min: 5, max: 10, error: testError)
 
-        let tooSmall = Validator.validate(input: 4, rule: rule)
+        let tooSmall = Validator.performValidation(input: 4, rule: rule)
         XCTAssertFalse(tooSmall.isValid)
 
-        let tooLarge = Validator.validate(input: 11, rule: rule)
+        let tooLarge = Validator.performValidation(input: 11, rule: rule)
         XCTAssertFalse(tooLarge.isValid)
 
         for n in (5...10) {
-            let valid = Validator.validate(input: n, rule: rule)
+            let valid = Validator.performValidation(input: n, rule: rule)
             XCTAssertTrue(valid.isValid)
         }
 
@@ -53,14 +53,14 @@ class ValidationRuleComparisonTests: XCTestCase {
 
         let rule = ValidationRuleComparison<Double>(min: 5.0, max: 10.0, error: testError)
 
-        let tooSmall = Validator.validate(input: 4.0, rule: rule)
+        let tooSmall = Validator.performValidation(input: 4.0, rule: rule)
         XCTAssertFalse(tooSmall.isValid)
 
-        let tooLarge = Validator.validate(input: 10.1, rule: rule)
+        let tooLarge = Validator.performValidation(input: 10.1, rule: rule)
         XCTAssertFalse(tooLarge.isValid)
 
         for n in [5.4, 6.2, 7.7, 8.3, 9.1, 10.0] {
-            let valid = Validator.validate(input: n, rule: rule)
+            let valid = Validator.performValidation(input: n, rule: rule)
             XCTAssertTrue(valid.isValid)
         }
         

--- a/Validator/ValidatorTests/Rules/ValidationRuleConditionTests.swift
+++ b/Validator/ValidatorTests/Rules/ValidationRuleConditionTests.swift
@@ -36,18 +36,18 @@ class ValidationRuleConditionTests: XCTestCase {
 //
 //        let ruleA = ValidationRuleCondition<String>(error: testError) { $0?.range(of: "A") == nil }
 //        
-//        let invalidA = Validator.validate(input: "invAlid", rule: ruleA)
+//        let invalidA = Validator.performValidation(input: "invAlid", rule: ruleA)
 //        XCTAssertFalse(invalidA.isValid)
 //        
-//        let validA = Validator.validate(input: "😀", rule: ruleA)
+//        let validA = Validator.performValidation(input: "😀", rule: ruleA)
 //        XCTAssertTrue(validA.isValid)
 //        
 //        let ruleB = ValidationRuleCondition<[Int]>(error: testError) { $0!.reduce(0, +) > 50 }
 //
-//        let invalidB = Validator.validate(input: [40, 1, 5], rule: ruleB)
+//        let invalidB = Validator.performValidation(input: [40, 1, 5], rule: ruleB)
 //        XCTAssertFalse(invalidB.isValid)
 //        
-//        let validB = Validator.validate(input: [45, 1, 5], rule: ruleB)
+//        let validB = Validator.performValidation(input: [45, 1, 5], rule: ruleB)
 //        XCTAssertTrue(validB.isValid)
 //        
 //    }

--- a/Validator/ValidatorTests/Rules/ValidationRuleContainsTests.swift
+++ b/Validator/ValidatorTests/Rules/ValidationRuleContainsTests.swift
@@ -37,12 +37,12 @@ class ValidationRuleContainsTests: XCTestCase {
         let rule = ValidationRuleContains<String, [String]>(sequence: ["hello", "hi", "hey"], error: testError)
         
         for notInSequence in ["adam", "😋", "HEY"] {
-            let invalid = Validator.validate(input: notInSequence, rule: rule)
+            let invalid = Validator.performValidation(input: notInSequence, rule: rule)
             XCTAssertFalse(invalid.isValid)
         }
         
         for inSequence in ["hello", "hi", "hey"] {
-            let valid = Validator.validate(input: inSequence, rule: rule)
+            let valid = Validator.performValidation(input: inSequence, rule: rule)
             XCTAssertTrue(valid.isValid)
         }
     }
@@ -52,12 +52,12 @@ class ValidationRuleContainsTests: XCTestCase {
         let rule = ValidationRuleContains<Int, [Int]>(sequence: [1, 2, 3], error: testError)
         
         for notInSequence in [4, 5, 6] {
-            let invalid = Validator.validate(input: notInSequence, rule: rule)
+            let invalid = Validator.performValidation(input: notInSequence, rule: rule)
             XCTAssertFalse(invalid.isValid)
         }
         
         for inSequence in [1, 2, 3] {
-            let valid = Validator.validate(input: inSequence, rule: rule)
+            let valid = Validator.performValidation(input: inSequence, rule: rule)
             XCTAssertTrue(valid.isValid)
         }
     }

--- a/Validator/ValidatorTests/Rules/ValidationRuleEqualityTests.swift
+++ b/Validator/ValidatorTests/Rules/ValidationRuleEqualityTests.swift
@@ -36,10 +36,10 @@ class ValidationRuleEqualityTests: XCTestCase {
         
         let rule = ValidationRuleEquality<String>(target: "password", error: testError)
         
-        let invalid = Validator.validate(input: "p@ssword", rule: rule)
+        let invalid = Validator.performValidation(input: "p@ssword", rule: rule)
         XCTAssertFalse(invalid.isValid)
 
-        let valid = Validator.validate(input:"password", rule: rule)
+        let valid = Validator.performValidation(input:"password", rule: rule)
         XCTAssertTrue(valid.isValid)
         
     }
@@ -48,10 +48,10 @@ class ValidationRuleEqualityTests: XCTestCase {
         
         let rule = ValidationRuleEquality<Double>(target: 1.0, error: testError)
         
-        let invalid = Validator.validate(input: 2.0, rule: rule)
+        let invalid = Validator.performValidation(input: 2.0, rule: rule)
         XCTAssertFalse(invalid.isValid)
         
-        let valid = Validator.validate(input: 1.0, rule: rule)
+        let valid = Validator.performValidation(input: 1.0, rule: rule)
         XCTAssertTrue(valid.isValid)
         
     }
@@ -64,10 +64,10 @@ class ValidationRuleEqualityTests: XCTestCase {
         
         let rule = ValidationRuleEquality<String>(dynamicTarget: getter, error: testError)
         
-        let invalid = Validator.validate(input: "p@ssword", rule: rule)
+        let invalid = Validator.performValidation(input: "p@ssword", rule: rule)
         XCTAssertFalse(invalid.isValid)
         
-        let valid = Validator.validate(input: "password", rule: rule)
+        let valid = Validator.performValidation(input: "password", rule: rule)
         XCTAssertTrue(valid.isValid)
         
     }

--- a/Validator/ValidatorTests/Rules/ValidationRuleLengthTests.swift
+++ b/Validator/ValidatorTests/Rules/ValidationRuleLengthTests.swift
@@ -36,10 +36,10 @@ class ValidationRuleLengthTests: XCTestCase {
         
         let rule = ValidationRuleLength(min: 5, error: testError)
         
-        let tooShort = Validator.validate(input: "aaaa", rule: rule)
+        let tooShort = Validator.performValidation(input: "aaaa", rule: rule)
         XCTAssertFalse(tooShort.isValid)
         
-        let valid = Validator.validate(input: "aaaaa", rule: rule)
+        let valid = Validator.performValidation(input: "aaaaa", rule: rule)
         XCTAssertTrue(valid.isValid)
         
     }
@@ -48,10 +48,10 @@ class ValidationRuleLengthTests: XCTestCase {
         
         let rule = ValidationRuleLength(max: 5, error: testError)
         
-        let tooLong = Validator.validate(input: "aaaaaa", rule: rule)
+        let tooLong = Validator.performValidation(input: "aaaaaa", rule: rule)
         XCTAssertFalse(tooLong.isValid)
         
-        let valid = Validator.validate(input: "aaaaa", rule: rule)
+        let valid = Validator.performValidation(input: "aaaaa", rule: rule)
         XCTAssertTrue(valid.isValid)
         
     }
@@ -60,14 +60,14 @@ class ValidationRuleLengthTests: XCTestCase {
         
         let rule = ValidationRuleLength(min: 5, max: 10, error: testError)
         
-        let tooShort = Validator.validate(input: "aaaa", rule: rule)
+        let tooShort = Validator.performValidation(input: "aaaa", rule: rule)
         XCTAssertFalse(tooShort.isValid)
     
-        let tooLong = Validator.validate(input: "aaaaaaaaaaa", rule: rule)
+        let tooLong = Validator.performValidation(input: "aaaaaaaaaaa", rule: rule)
         XCTAssertFalse(tooLong.isValid)
         
         for input in ["aaaaa", "aaaaaaaaaa", "aaaaaaaa"] {
-            let valid = Validator.validate(input: input, rule: rule)
+            let valid = Validator.performValidation(input: input, rule: rule)
             XCTAssertTrue(valid.isValid)
         }
         
@@ -78,10 +78,10 @@ class ValidationRuleLengthTests: XCTestCase {
 
         let rule = ValidationRuleLength(min: 2, error: testError)
 
-        let tooShort = Validator.validate(input: "🇯🇵", rule: rule)
+        let tooShort = Validator.performValidation(input: "🇯🇵", rule: rule)
         XCTAssertFalse(tooShort.isValid)
 
-        let valid = Validator.validate(input: "🇯🇵🇯🇵", rule: rule)
+        let valid = Validator.performValidation(input: "🇯🇵🇯🇵", rule: rule)
         XCTAssertTrue(valid.isValid)
     }
 
@@ -90,10 +90,10 @@ class ValidationRuleLengthTests: XCTestCase {
 
         let rule = ValidationRuleLength(max: 2, error: testError)
 
-        let tooLong = Validator.validate(input: "🇯🇵🇯🇵🇯🇵", rule: rule)
+        let tooLong = Validator.performValidation(input: "🇯🇵🇯🇵🇯🇵", rule: rule)
         XCTAssertFalse(tooLong.isValid)
 
-        let valid = Validator.validate(input: "🇯🇵🇯🇵", rule: rule)
+        let valid = Validator.performValidation(input: "🇯🇵🇯🇵", rule: rule)
         XCTAssertTrue(valid.isValid)
     }
 
@@ -102,10 +102,10 @@ class ValidationRuleLengthTests: XCTestCase {
 
         let rule = ValidationRuleLength(min: 16, lengthType: .utf8, error: testError)
 
-        let tooShort = Validator.validate(input: "🇯🇵", rule: rule)
+        let tooShort = Validator.performValidation(input: "🇯🇵", rule: rule)
         XCTAssertFalse(tooShort.isValid)
 
-        let valid = Validator.validate(input: "🇯🇵🇯🇵", rule: rule)
+        let valid = Validator.performValidation(input: "🇯🇵🇯🇵", rule: rule)
         XCTAssertTrue(valid.isValid)
     }
 
@@ -114,10 +114,10 @@ class ValidationRuleLengthTests: XCTestCase {
 
         let rule = ValidationRuleLength(max: 16, lengthType: .utf8, error: testError)
 
-        let tooLong = Validator.validate(input: "🇯🇵🇯🇵🇯🇵", rule: rule)
+        let tooLong = Validator.performValidation(input: "🇯🇵🇯🇵🇯🇵", rule: rule)
         XCTAssertFalse(tooLong.isValid)
 
-        let valid = Validator.validate(input: "🇯🇵🇯🇵", rule: rule)
+        let valid = Validator.performValidation(input: "🇯🇵🇯🇵", rule: rule)
         XCTAssertTrue(valid.isValid)
     }
 
@@ -126,10 +126,10 @@ class ValidationRuleLengthTests: XCTestCase {
 
         let rule = ValidationRuleLength(min: 8, lengthType: .utf16, error: testError)
 
-        let tooShort = Validator.validate(input: "🇯🇵", rule: rule)
+        let tooShort = Validator.performValidation(input: "🇯🇵", rule: rule)
         XCTAssertFalse(tooShort.isValid)
 
-        let valid = Validator.validate(input: "🇯🇵🇯🇵", rule: rule)
+        let valid = Validator.performValidation(input: "🇯🇵🇯🇵", rule: rule)
         XCTAssertTrue(valid.isValid)
     }
 
@@ -138,10 +138,10 @@ class ValidationRuleLengthTests: XCTestCase {
 
         let rule = ValidationRuleLength(max: 8, lengthType: .utf16, error: testError)
 
-        let tooLong = Validator.validate(input: "🇯🇵🇯🇵🇯🇵", rule: rule)
+        let tooLong = Validator.performValidation(input: "🇯🇵🇯🇵🇯🇵", rule: rule)
         XCTAssertFalse(tooLong.isValid)
 
-        let valid = Validator.validate(input: "🇯🇵🇯🇵", rule: rule)
+        let valid = Validator.performValidation(input: "🇯🇵🇯🇵", rule: rule)
         XCTAssertTrue(valid.isValid)
     }
 
@@ -150,10 +150,10 @@ class ValidationRuleLengthTests: XCTestCase {
 
         let rule = ValidationRuleLength(min: 4, lengthType: .unicodeScalars, error: testError)
 
-        let tooShort = Validator.validate(input: "🇯🇵", rule: rule)
+        let tooShort = Validator.performValidation(input: "🇯🇵", rule: rule)
         XCTAssertFalse(tooShort.isValid)
 
-        let valid = Validator.validate(input: "🇯🇵🇯🇵", rule: rule)
+        let valid = Validator.performValidation(input: "🇯🇵🇯🇵", rule: rule)
         XCTAssertTrue(valid.isValid)
     }
 
@@ -162,10 +162,10 @@ class ValidationRuleLengthTests: XCTestCase {
 
         let rule = ValidationRuleLength(max: 4, lengthType: .unicodeScalars, error: testError)
 
-        let tooLong = Validator.validate(input: "🇯🇵🇯🇵🇯🇵", rule: rule)
+        let tooLong = Validator.performValidation(input: "🇯🇵🇯🇵🇯🇵", rule: rule)
         XCTAssertFalse(tooLong.isValid)
 
-        let valid = Validator.validate(input: "🇯🇵🇯🇵", rule: rule)
+        let valid = Validator.performValidation(input: "🇯🇵🇯🇵", rule: rule)
         XCTAssertTrue(valid.isValid)
     }
 }

--- a/Validator/ValidatorTests/Rules/ValidationRulePatternTests.swift
+++ b/Validator/ValidatorTests/Rules/ValidationRulePatternTests.swift
@@ -37,12 +37,12 @@ class ValidationRulePatternTests: XCTestCase {
         let rule = ValidationRulePattern(pattern: EmailValidationPattern.standard, error: testError)
 
         for invalidEmail in ["user@invalid,com", "userinvalid.com", "invalid", "user@invalid@example.com"] {
-            let invalid = Validator.validate(input: invalidEmail, rule: rule)
+            let invalid = Validator.performValidation(input: invalidEmail, rule: rule)
             XCTAssertFalse(invalid.isValid, invalidEmail)
         }
         
         for validEmail in ["user@valid.com", "user_1@valid.co.uk", "user@valid.museum"] {
-            let valid = Validator.validate(input: validEmail, rule: rule)
+            let valid = Validator.performValidation(input: validEmail, rule: rule)
             XCTAssertTrue(valid.isValid)
         }
         
@@ -53,12 +53,12 @@ class ValidationRulePatternTests: XCTestCase {
         let rule = ValidationRulePattern(pattern: ContainsNumberValidationPattern(), error: testError)
         
         for noDigitString in ["invalid", "invali_d", "inv+alid"] {
-            let invalid = Validator.validate(input: noDigitString, rule: rule)
+            let invalid = Validator.performValidation(input: noDigitString, rule: rule)
             XCTAssertFalse(invalid.isValid)
         }
         
         for digitString in ["valid1", "9valid"] {
-            let valid = Validator.validate(input: digitString, rule: rule)
+            let valid = Validator.performValidation(input: digitString, rule: rule)
             XCTAssertTrue(valid.isValid)
         }
         

--- a/Validator/ValidatorTests/Rules/ValidationRulePaymentCardTests.swift
+++ b/Validator/ValidatorTests/Rules/ValidationRulePaymentCardTests.swift
@@ -106,23 +106,23 @@ class ValidationRulePaymentCardTests: XCTestCase {
         let rule = ValidationRulePaymentCard(error: testError)
         
         for invalidLuhn in ["5716347184862961", "49927398717"] {
-            let invalid = Validator.validate(input: invalidLuhn, rule: rule)
+            let invalid = Validator.performValidation(input: invalidLuhn, rule: rule)
             XCTAssertFalse(invalid.isValid)
         }
         
         for validLuhn in ["4716347184862961", "49927398716"] {
-            let valid = Validator.validate(input: validLuhn, rule: rule)
+            let valid = Validator.performValidation(input: validLuhn, rule: rule)
             XCTAssertTrue(valid.isValid)
         }
         
         5.times { _ in
-            let validVisa = Validator.validate(input: self.visaCardNumbers.random, rule: rule)
+            let validVisa = Validator.performValidation(input: self.visaCardNumbers.random, rule: rule)
             XCTAssertTrue(validVisa.isValid)
-            let validMastercard = Validator.validate(input: self.mastercardCardNumbers.random, rule: rule)
+            let validMastercard = Validator.performValidation(input: self.mastercardCardNumbers.random, rule: rule)
             XCTAssertTrue(validMastercard.isValid)
-            let validMaestro = Validator.validate(input: self.maestroCardNumbers.random, rule: rule)
+            let validMaestro = Validator.performValidation(input: self.maestroCardNumbers.random, rule: rule)
             XCTAssertTrue(validMaestro.isValid)
-            let validAmex = Validator.validate(input: self.amexCardNumbers.random, rule: rule)
+            let validAmex = Validator.performValidation(input: self.amexCardNumbers.random, rule: rule)
             XCTAssertTrue(validAmex.isValid)
         }
     }
@@ -136,14 +136,14 @@ class ValidationRulePaymentCardTests: XCTestCase {
         let mastercard = mastercardCardNumbers.random
         let maestro = maestroCardNumbers.random
         
-        XCTAssertFalse(Validator.validate(input: visa, rule: amexOnlyRule).isValid)
-        XCTAssertFalse(Validator.validate(input: mastercard, rule: amexOnlyRule).isValid)
-        XCTAssertFalse(Validator.validate(input: maestro, rule: amexOnlyRule).isValid)
-        XCTAssertTrue(Validator.validate(input: amex, rule: amexOnlyRule).isValid)
+        XCTAssertFalse(Validator.performValidation(input: visa, rule: amexOnlyRule).isValid)
+        XCTAssertFalse(Validator.performValidation(input: mastercard, rule: amexOnlyRule).isValid)
+        XCTAssertFalse(Validator.performValidation(input: maestro, rule: amexOnlyRule).isValid)
+        XCTAssertTrue(Validator.performValidation(input: amex, rule: amexOnlyRule).isValid)
 
-        XCTAssertFalse(Validator.validate(input: amex, rule: visaOrMasterCardRule).isValid)
-        XCTAssertFalse(Validator.validate(input: maestro, rule: visaOrMasterCardRule).isValid)
-        XCTAssertTrue(Validator.validate(input: visa, rule: visaOrMasterCardRule).isValid)
-        XCTAssertTrue(Validator.validate(input: mastercard, rule: visaOrMasterCardRule).isValid)
+        XCTAssertFalse(Validator.performValidation(input: amex, rule: visaOrMasterCardRule).isValid)
+        XCTAssertFalse(Validator.performValidation(input: maestro, rule: visaOrMasterCardRule).isValid)
+        XCTAssertTrue(Validator.performValidation(input: visa, rule: visaOrMasterCardRule).isValid)
+        XCTAssertTrue(Validator.performValidation(input: mastercard, rule: visaOrMasterCardRule).isValid)
     }
 }

--- a/Validator/ValidatorTests/Rules/ValidationRuleRequiredTests.swift
+++ b/Validator/ValidatorTests/Rules/ValidationRuleRequiredTests.swift
@@ -36,10 +36,10 @@ class ValidationRuleRequiredTests: XCTestCase {
 
         let rule = ValidationRuleRequired<String?>(error: testError)
 
-        let invalid = Validator.validate(input: nil, rule: rule)
+        let invalid = Validator.performValidation(input: nil, rule: rule)
         XCTAssertFalse(invalid.isValid)
 
-        let valid = Validator.validate(input: "hello", rule: rule)
+        let valid = Validator.performValidation(input: "hello", rule: rule)
         XCTAssertTrue(valid.isValid)
 
     }

--- a/Validator/ValidatorTests/Rules/ValidationRuleURLTests.swift
+++ b/Validator/ValidatorTests/Rules/ValidationRuleURLTests.swift
@@ -37,12 +37,12 @@ class ValidationRuleURLTests: XCTestCase {
         let rule = ValidationRuleURL(error: testError)
         
         for invalidURL in ["http:▷adamjwaite.co.uk", "http://adamjwaite.co.uk?hello=😋"] {
-            let invalid = Validator.validate(input: invalidURL, rule: rule)
+            let invalid = Validator.performValidation(input: invalidURL, rule: rule)
             XCTAssertFalse(invalid.isValid)
         }
         
         for validURL in ["http://adamjwaite.co.uk", "http://google.com"] {
-            let valid = Validator.validate(input: validURL, rule: rule)
+            let valid = Validator.performValidation(input: validURL, rule: rule)
             XCTAssertTrue(valid.isValid)
         }
         

--- a/Validator/ValidatorTests/UIKit+Validator/UISlider+ValidatorTests.swift
+++ b/Validator/ValidatorTests/UIKit+Validator/UISlider+ValidatorTests.swift
@@ -53,18 +53,18 @@ class UISliderValidatorTests: XCTestCase {
 
         slider.value = 1.0
         
-        let tooSmall = slider.validate(rule: rule)
+        let tooSmall = slider.performValidation(rule: rule)
         XCTAssertFalse(tooSmall.isValid)
         
         slider.value = 8.0
         
-        let tooBig = slider.validate(rule: rule)
+        let tooBig = slider.performValidation(rule: rule)
         XCTAssertFalse(tooBig.isValid)
 
         slider.value = 4.0
         XCTAssertTrue(slider.inputValue == 4.0)
         
-        let valid = slider.validate(rule: rule)
+        let valid = slider.performValidation(rule: rule)
         XCTAssertTrue(valid.isValid)
         
     }

--- a/Validator/ValidatorTests/UIKit+Validator/UITextField+ValidatorTests.swift
+++ b/Validator/ValidatorTests/UIKit+Validator/UITextField+ValidatorTests.swift
@@ -45,13 +45,13 @@ class UITextFieldValidatorTests: XCTestCase {
     func testThatItCanValidateInputText() {
         let textField = UITextField()
         textField.text = "Hello"
-        let noRulesValidation = textField.validate()
+        let noRulesValidation = textField.performValidation()
         XCTAssertTrue(noRulesValidation.isValid)
         let rule = ValidationRuleCondition<String>(error: testError) { ($0?.contains("A"))! }
-        let invalid = textField.validate(rule: rule)
+        let invalid = textField.performValidation(rule: rule)
         XCTAssertFalse(invalid.isValid)
         textField.text = "Hello Adam"
-        let valid = textField.validate(rule: rule)
+        let valid = textField.performValidation(rule: rule)
         XCTAssertTrue(valid.isValid)
     }
     
@@ -68,7 +68,7 @@ class UITextFieldValidatorTests: XCTestCase {
         textField.validationRules = rules
         XCTAssertNotNil(textField.validationRules)
         
-        textField.validateOnInputChange(enabled: true)
+        textField.performValidationOnInputChange(enabled: true)
         let actions = textField.actions(forTarget: textField, forControlEvent: .editingChanged) ?? []
         XCTAssertFalse(actions.isEmpty)
 
@@ -80,12 +80,12 @@ class UITextFieldValidatorTests: XCTestCase {
         }
         
         textField.text = "BCDE"
-        let _ = textField.validate() // textField.sendActionsForControlEvents(.EditingChanged) doesn't seem to work in test env
+        let _ = textField.performValidation() // textField.sendActionsForControlEvents(.EditingChanged) doesn't seem to work in test env
         XCTAssert(didRegisterInvalid)
         XCTAssertFalse(didRegisterValid)
         
         textField.text = "ABCDE"
-        let _ = textField.validate()
+        let _ = textField.performValidation()
         XCTAssert(didRegisterInvalid)
         XCTAssert(didRegisterValid)
     }

--- a/Validator/ValidatorTests/UIKit+Validator/ValidatableInterfaceElementTests.swift
+++ b/Validator/ValidatorTests/UIKit+Validator/ValidatableInterfaceElementTests.swift
@@ -39,12 +39,12 @@ class ValidatableInterfaceElementTests: XCTestCase {
         
         let rule = ValidationRuleCondition<String>(error: testError) { $0!.characters.contains("A") }
         
-        let invalid = textField.validate(rule: rule)
+        let invalid = textField.performValidation(rule: rule)
         XCTAssertFalse(invalid.isValid)
         
         textField.text = "Hello Adam"
         
-        let valid = textField.validate(rule: rule)
+        let valid = textField.performValidation(rule: rule)
         XCTAssertTrue(valid.isValid)
         
     }
@@ -58,17 +58,17 @@ class ValidatableInterfaceElementTests: XCTestCase {
         rules.add(rule: ValidationRuleLength(min: 5, error: testError))
         rules.add(rule: ValidationRuleCondition<String>(error: testError) { ($0?.characters.contains("A"))! })
         
-        let definitelyInvalid = textField.validate(rules: rules)
+        let definitelyInvalid = textField.performValidation(rules: rules)
         XCTAssertFalse(definitelyInvalid.isValid)
         
         textField.text = "Hi adam"
         
-        let partiallyInvalid = textField.validate(rules: rules)
+        let partiallyInvalid = textField.performValidation(rules: rules)
         XCTAssertFalse(partiallyInvalid.isValid)
         
         textField.text = "Hi Adam"
         
-        let valid = textField.validate(rules: rules)
+        let valid = textField.performValidation(rules: rules)
         XCTAssertTrue(valid.isValid)
         
     }
@@ -85,12 +85,12 @@ class ValidatableInterfaceElementTests: XCTestCase {
         
         textField.text = "Hi adam"
         
-        let invalid = textField.validate()
+        let invalid = textField.performValidation()
         XCTAssertFalse(invalid.isValid)
         
         textField.text = "Hi Adam"
 
-        let valid = textField.validate()
+        let valid = textField.performValidation()
         XCTAssertTrue(valid.isValid)
         
     }

--- a/Validator/ValidatorTests/Validatable/ValidatableTests.swift
+++ b/Validator/ValidatorTests/Validatable/ValidatableTests.swift
@@ -32,14 +32,14 @@ import XCTest
 
 class ValidatableTests: XCTestCase {
     
-    func testThatItCanValidate() {
+    func testThatItCanPerformValidation() {
         
         let rule = ValidationRuleCondition<String>(error: testError) { ($0?.count)! > 0 }
         
-        let invalid = "".validate(rule: rule)
+        let invalid = "".performValidation(rule: rule)
         XCTAssertFalse(invalid.isValid)
         
-        let valid = "😀".validate(rule: rule)
+        let valid = "😀".performValidation(rule: rule)
         XCTAssertTrue(valid.isValid)
         
     }

--- a/Validator/ValidatorTests/Validator/ValidatorTests.swift
+++ b/Validator/ValidatorTests/Validator/ValidatorTests.swift
@@ -38,10 +38,10 @@ class ValidatorTests: XCTestCase {
         
         let rule = ValidationRuleCondition<String>(error: err) { ($0?.count)! > 0 }
         
-        let invalid = Validator.validate(input: "", rule: rule)
+        let invalid = Validator.performValidation(input: "", rule: rule)
         XCTAssertEqual(invalid, ValidationResult.invalid([err]))
         
-        let valid = Validator.validate(input: "😀", rule: rule)
+        let valid = Validator.performValidation(input: "😀", rule: rule)
         XCTAssertEqual(valid, ValidationResult.valid)
         
     }
@@ -55,13 +55,13 @@ class ValidatorTests: XCTestCase {
         ruleSet.add(rule: ValidationRuleLength(min: 1, error: err1))
         ruleSet.add(rule: ValidationRuleCondition<String>(error: err2) { $0 == "😀" })
         
-        let definitelyInvalid = Validator.validate(input: "", rules: ruleSet)
+        let definitelyInvalid = Validator.performValidation(input: "", rules: ruleSet)
         XCTAssertEqual(definitelyInvalid, ValidationResult.invalid([err1, err2]))
         
-        let partiallyValid = "😁".validate(rules: ruleSet)
+        let partiallyValid = "😁".performValidation(rules: ruleSet)
         XCTAssertEqual(partiallyValid, ValidationResult.invalid([err2]))
 
-        let valid = "😀".validate(rules: ruleSet)
+        let valid = "😀".performValidation(rules: ruleSet)
         XCTAssertEqual(valid, ValidationResult.valid)
         
     }


### PR DESCRIPTION
Many SwiftUI/UIKit elements now provide a validate method, and this namespace conflict makes it confusing to use Validator and breaks a handful of selectors with ambiguity warnings: `Ambiguous use of 'validate'`.